### PR TITLE
Added ability to provide full config map for client

### DIFF
--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -14,9 +14,10 @@
 (def ^:const output-stream-buffer-size (* 1024 1024))
 
 (defn redis-client
-  [opts]
-  {:pool (car/connection-pool (or (:pool opts) {}))
-   :spec {:uri (:uri opts)
+  [{:keys [pool uri spec] :as opts}]
+  (when spec (merge {:pool (car/connection-pool {})} opts))
+  {:pool (car/connection-pool (or pool {}))
+   :spec {:uri    uri
           :ssl-fn :default}})
 
 (defn put-object [client ^String key ^bytes bytes]


### PR DESCRIPTION
Straightforward, takes a map, when spec is present it gets used along with at minimum an empty pool, when-not it functions as before. No breakage.

As for the S3 client. I've got nothing for you. I stared at it, but since it's an override there isn't a good way in my mind to process the map not knowing what specifically needs to get built, at that point it's a lot of ifs inside of a cond-> inside of a thread first and ain't nobody want to look at that.

Anyways, I'm liking treating all my kv-stores like maps. Appreciate the work you've put in. I'll be more useful in the future when I can.