### PR TITLE
Allow non-ssl connections and more.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  tools: replikativ/clj-tools@0
+  tools: replikativ/clj-tools@0.0.30
 
 workflows:
   build-test-and-deploy:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ For asynchronous execution take a look at the [konserve example](https://github.
 
 (def redis-spec
   {:uri "redis://localhost:6379/"
-   ;; Use `:ssl-fn :default` when Redis requires SSL, otherwise omit.
-   :ssl-fn :default})
+   ;; Connection pools are used by default, use `:pool :none` to disable.
+   :pool :none
+   ;; Redis is assumed to require SSL, use `:ssl-fn :none` to disable.
+   :ssl-fn :none})
 
 (def store (connect-store redis-spec :opts {:sync? true}))
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ For asynchronous execution take a look at the [konserve example](https://github.
          '[konserve.core :as k])
 
 (def redis-spec
-  {:uri "redis://localhost:6379/"})
+  {:uri "redis://localhost:6379/"
+   ;; Use `:ssl-fn :default` when Redis requires SSL, otherwise omit.
+   :ssl-fn :default})
 
 (def store (connect-store redis-spec :opts {:sync? true}))
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Add to your dependencies:
 For asynchronous execution take a look at the [konserve example](https://github.com/replikativ/konserve#asynchronous-execution).
 
 ``` clojure
-(require '[konserve-redis.core :refer [connect-redis-store]]
+(require '[konserve-redis.core :refer [connect-store]]
          '[konserve.core :as k])
 
 (def redis-spec
   {:uri "redis://localhost:9475/"})
 
-(def store (connect-redis-store redis-spec :opts {:sync? true}))
+(def store (connect-store redis-spec :opts {:sync? true}))
 
 (k/assoc-in store ["foo" :bar] {:foo "baz"} {:sync? true})
 (k/get-in store ["foo"] nil {:sync? true})

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For asynchronous execution take a look at the [konserve example](https://github.
          '[konserve.core :as k])
 
 (def redis-spec
-  {:uri "redis://localhost:9475/"})
+  {:uri "redis://localhost:6379/"})
 
 (def store (connect-store redis-spec :opts {:sync? true}))
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,23 +1,23 @@
 {:paths ["src"]
- :deps {com.taoensso/timbre {:mvn/version "5.1.2"}
-        io.replikativ/konserve {:mvn/version "0.7.285"}
-        io.replikativ/superv.async {:mvn/version "0.3.43"}
-        org.clojure/clojure {:mvn/version "1.10.3"}
-        com.taoensso/carmine {:mvn/version "3.2.0"}}
- :aliases {:test   {:extra-deps  {lambdaisland/kaocha {:mvn/version "1.60.977"}}
+ :deps {com.taoensso/timbre {:mvn/version "6.6.1"}
+        io.replikativ/konserve {:mvn/version "0.7.319"}
+        io.replikativ/superv.async {:mvn/version "0.3.48"}
+        org.clojure/clojure {:mvn/version "1.12.0"}
+        com.taoensso/carmine {:mvn/version "3.4.1"}}
+ :aliases {:test   {:extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
                     :extra-paths ["test"]}
-           :jar    {:extra-deps {seancorfield/depstar {:mvn/version "1.1.116"}}
+           :jar    {:extra-deps {seancorfield/depstar {:mvn/version "2.0.216"}}
                     :main-opts ["-m" "hf.depstar.jar" "replikativ-konserve-redis.jar"]}
-           :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
+           :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}
                     :main-opts ["-m" "cljfmt.main" "check"]}
-           :ffix   {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+           :ffix   {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}
                     :main-opts ["-m" "cljfmt.main" "fix"]}
-           :build  {:deps {io.github.clojure/tools.build          {:mvn/version "0.9.3"}
-                           slipset/deps-deploy                    {:mvn/version "0.2.0"}
-                           io.github.borkdude/gh-release-artifact {:git/sha "05f8d8659e6805d513c59447ff41dc8497878462"}
+           :build  {:deps {io.github.clojure/tools.build          {:mvn/version "0.10.6"}
+                           slipset/deps-deploy                    {:mvn/version "0.2.2"}
+                           io.github.borkdude/gh-release-artifact {:git/sha "4a9a74f0e50e897c45df8cc70684360eb30fce80"}
                            babashka/babashka.curl                 {:mvn/version "0.1.2"}
-                           babashka/fs                            {:mvn/version "0.1.6"}
-                           cheshire/cheshire                      {:mvn/version "5.10.2"}}
+                           babashka/fs                            {:mvn/version "0.5.23"}
+                           cheshire/cheshire                      {:mvn/version "5.13.0"}}
                     :ns-default build}
            :outdated {:deps {com.github.liquidz/antq {:mvn/version "2.11.1260"}}
                       :main-opts ["-m" "antq.core"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -18,4 +18,6 @@
                            babashka/babashka.curl                 {:mvn/version "0.1.2"}
                            babashka/fs                            {:mvn/version "0.1.6"}
                            cheshire/cheshire                      {:mvn/version "5.10.2"}}
-                    :ns-default build}}}
+                    :ns-default build}
+           :outdated {:deps {com.github.liquidz/antq {:mvn/version "2.11.1260"}}
+                      :main-opts ["-m" "antq.core"]}}}

--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -14,10 +14,10 @@
 (def ^:const output-stream-buffer-size (* 1024 1024))
 
 (defn redis-client
-  [{:keys [pool uri]}]
+  [{:keys [pool ssl-fn uri]}]
   (merge
    {:spec {:uri uri
-           :ssl-fn :default}}
+           :ssl-fn ssl-fn}}
    (when pool
      {:pool (car/connection-pool pool)})))
 

--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -174,7 +174,7 @@
 
   (require '[konserve.core :as k])
 
-  (def redis-spec {:uri "redis://localhost:9475/"})
+  (def redis-spec {:uri "redis://localhost:6379/"})
 
   (def test-client (redis-client redis-spec))
 

--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -14,10 +14,12 @@
 (def ^:const output-stream-buffer-size (* 1024 1024))
 
 (defn redis-client
-  [opts]
-  {:pool (car/connection-pool (or (:pool opts) {}))
-   :spec {:uri (:uri opts)
-          :ssl-fn :default}})
+  [{:keys [pool uri]}]
+  (merge
+   {:spec {:uri uri
+           :ssl-fn :default}}
+   (when pool
+     {:pool (car/connection-pool pool)})))
 
 (defn put-object [client ^String key ^bytes bytes]
   (wcar client (car/set key bytes)))

--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -15,11 +15,11 @@
 
 (defn redis-client
   [{:keys [pool ssl-fn uri]}]
-  (merge
-   {:spec {:uri uri
-           :ssl-fn ssl-fn}}
-   (when pool
-     {:pool (car/connection-pool pool)})))
+  (merge {:spec (merge {:uri uri}
+                       (when-not (= ssl-fn :none)
+                         {:ssl-fn (or ssl-fn :default)}))}
+         (when-not (= pool :none)
+           {:pool (car/connection-pool (or pool {}))})))
 
 (defn put-object [client ^String key ^bytes bytes]
   (wcar client (car/set key bytes)))

--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -164,8 +164,9 @@
 (defn release
   "Must be called after work on database has finished in order to close connection"
   [store env]
-  (async+sync (:sync? env) *default-sync-translation*
-              (go-try- (.close (:pool (:client (:backing store)))))))
+  (when-let [pool (-> store :backing :client :pool)]
+    (async+sync (:sync? env) *default-sync-translation*
+                (go-try- (.close pool)))))
 
 (defn delete-store [redis-spec & {:keys [opts]}]
   (let [complete-opts (merge {:sync? true} opts)

--- a/test/konserve_redis/core_test.clj
+++ b/test/konserve_redis/core_test.clj
@@ -4,7 +4,7 @@
             [konserve.compliance-test :refer [compliance-test]]
             [konserve-redis.core :refer [connect-store release delete-store]]))
 
-(def redis-spec {:uri "redis://localhost:9475/"})
+(def redis-spec {:uri "redis://localhost:6379/"})
 
 (deftest redis-compliance-sync-test
   (let [redis-spec (assoc redis-spec :bucket "konserve-redis-sync-test")
@@ -23,4 +23,3 @@
       (compliance-test store))
     (<!! (release store {:sync? false}))
     (<!! (delete-store redis-spec :opts {:sync? false}))))
-


### PR DESCRIPTION
This pull-request includes several changes. Happy to break this up if that's preferred.

The README has been updated to use connect-store instead of connect-redis-store which does not exist.

6379 is used as the default redis port. I don't know where 9475 came from. I don't see that redis binds to this port by default. Why was port 9475 used?

An alias for antq has been added to deps.edn, and all dependencies have been updated.

Do not include ssl-fn in the spec map when ssl-fn is :none so that non-ssl connections will be made to redis. Previously ssl-fn was hard-coded to :default which makes it impossible to use non-ssl connections. The default is still to assume ssl is required for backwards compatibility.

Skip connection pooling when pool is :none in the spec map. When I print the return value of connect-store I see an exception related to the connection pool (see below). I don't know what the cause of this is. Things still work, but the error goes away when I disable connection pooling. The default is still to use connection pooling for backwards compatibility.

```
#konserve.impl.defaults.DefaultStore{:version 1, :backing #konserve_redis.core.RedisStore{:client {:spec {:uri "redis://localhost:6379"}, :pool #taoensso.carmine.connections.ConnectionPool{:pool #object[org.apache.commons.pool2.impl.GenericKeyedObjectPool 0xd5fd6d6 "GenericKeyedObjectPool [maxTotal=-1, blockWhenExhausted=true, maxWaitDuration=PT-0.001S, lifo=true, fairness=false, testOnCreate=false, testOnBorrow=false, testOnReturn=false, testWhileIdle=true, durationBetweenEvictionRuns=PT30S, numTestsPerEvictionRun=-1, minEvictableIdleTimeDuration=PT1M, softMinEvictableIdleTimeDuration=PT-0.001S, evictionPolicy=org.apache.commons.pool2.impl.DefaultEvictionPolicy@4566ed3b, closeLock=java.lang.Object@36fc7a27, closed=false, evictionLock=java.lang.Object@77ebb57c, evictor=org.apache.commons.pool2.impl.BaseGenericObjectPool$Evictor [scheduledFuture=java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@6905efd1[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@4e80a4e5[Wrapped task = org.apache.commons.pool2.impl.EvictionTimer$WeakRunner@3c7d973b]]], evictionIterator=null, factoryClassLoader=java.lang.ref.WeakReference@436fe7d8, oname=org.apache.commons.pool2:type=GenericKeyedObjectPool,name=pool2, creationStackTrace=java.lang.Exception\n\tat org.apache.commons.pool2.impl.BaseGenericObjectPool.<init>(BaseGenericObjectPool.java:420)\n\tat org.apache.commons.pool2.impl.GenericKeyedObjectPool.<init>(GenericKeyedObjectPool.java:264)\n\tat org.apache.commons.pool2.impl.GenericKeyedObjectPool.<init>(GenericKeyedObjectPool.java:248)\n\tat taoensso.carmine.connections$fn__35778.invokeStatic(connections.clj:229)\n\tat taoensso.carmine.connections$fn__35778.invoke(connections.clj:206)\n\tat clojure.lang.AFn.applyToHelper(AFn.java:154)\n\tat clojure.lang.AFn.applyTo(AFn.java:144)\n\tat clojure.core$apply.invokeStatic(core.clj:667)\n\tat clojure.core$apply.invoke(core.clj:662)\n\tat taoensso.encore$cache$fn__26292$fn__26296.invoke(encore.cljc:3736)\n\tat clojure.lang.Delay.realize(Delay.java:44)\n\tat clojure.lang.Delay.deref(Delay.java:59)\n\tat clojure.core$deref.invokeStatic(core.clj:2337)\n\tat clojure.core$deref.invoke(core.clj:2323)\n\tat taoensso.encore$cache$fn__26292.doInvoke(encore.cljc:3724)\n\tat clojure.lang.RestFn.invoke(RestFn.java:424)\n\tat taoensso.carmine$connection_pool.invokeStatic(carmine.clj:63)\n\tat taoensso.carmine$connection_pool.invoke(carmine.clj:37)\n\tat konserve_redis.core$redis_client.invokeStatic(core.clj:22)\n\tat konserve_redis.core$redis_client.invoke(core.clj:16)\n\tat konserve_redis.core$connect_store.invokeStatic(core.clj:154)\n\tat konserve_redis.core$connect_store.doInvoke(core.clj:151)\n\tat clojure.lang.RestFn.invoke(RestFn.java:442)\n\tat bio.nalca.components.kv$eval46747.invokeStatic(NO_SOURCE_FILE:9)\n\tat bio.nalca.components.kv$eval46747.invoke(NO_SOURCE_FILE:9)\n\tat clojure.lang.Compiler.eval(Compiler.java:7700)\n\tat nrepl.middleware.interruptible_eval$evaluator$run__1435$fn__1446.invoke(interruptible_eval.clj:106)\n\tat nrepl.middleware.interruptible_eval$evaluator$run__1435.invoke(interruptible_eval.clj:101)\n\tat nrepl.middleware.session$session_exec$session_loop__1514.invoke(session.clj:229)\n\tat nrepl.SessionThread.run(SessionThread.java:21)\n, borrowedCount=0, returnedCount=0, createdCount=0, destroyedCount=0, destroyedByEvictorCount=0, destroyedByBorrowValidationCount=0, activeTimes=StatsStore [[]], size=100, index=0], idleTimes=StatsStore [[]], size=100, index=0], waitTimes=StatsStore [[]], size=100, index=0], maxBorrowWaitDuration=PT0S, swallowedExceptionListener=null, maxIdlePerKey=16, minIdlePerKey=0, maxTotalPerKey=16, factory=taoensso.carmine.connections$make_connection_factory$reify__35773@883d4dc, fairness=false, poolMap={}, poolKeyList=[], keyLock=java.util.concurrent.locks.ReentrantReadWriteLock@58174eb8[Write locks = 0, Read locks = 0], numTotal=0, evictionKeyIterator=null, evictionKey=null, abandonedConfig=null]"]}}}, :serializers {:StringSerializer #konserve.serializers.StringSerializer{}, :FressianSerializer #konserve.serializers.FressianSerializer{:custom-read-handlers {}, :custom-write-handlers {}}, :CBORSerializer #konserve.serializers.CBORSerializer{:codec #clj_cbor.codec.CBORCodec{:dispatch #function[clojure.core/class], :write-handlers {java.math.BigInteger #function[clj-cbor.tags.numbers/format-bignum], java.math.BigDecimal #function[clj-cbor.tags.numbers/format-big-decimal], clojure.lang.Keyword #function[clj-cbor.tags.clojure/format-symbol], clojure.lang.TaggedLiteral #function[clj-cbor.tags.clojure/format-tagged-literal], java.util.UUID #function[clj-cbor.tags.text/format-uuid], java.time.LocalDate #function[clj-cbor.tags.time/format-local-date-epoch], clojure.lang.BigInt #function[clj-cbor.tags.numbers/format-bignum], java.util.Date #function[clj-cbor.tags.time/format-date-epoch], java.util.regex.Pattern #function[clj-cbor.tags.text/format-pattern], java.time.Instant #function[clj-cbor.tags.time/format-instant-epoch], clojure.lang.Symbol #function[clj-cbor.tags.clojure/format-symbol], java.net.URI #function[clj-cbor.tags.text/format-uri], clojure.lang.Ratio #function[clj-cbor.tags.numbers/format-ratio]}, :read-handlers {0 #function[clj-cbor.tags.time/parse-string-instant], 27 #function[clj-cbor.tags.clojure/parse-tagged-literal], 1 #function[clj-cbor.tags.time/parse-epoch-instant], 39 #function[clj-cbor.tags.clojure/parse-symbol], 4 #function[clj-cbor.tags.numbers/parse-big-decimal], 55799 #function[clojure.core/identity], 32 #function[clj-cbor.tags.text/parse-uri], 100 #function[clj-cbor.tags.time/parse-epoch-local-date], 3 #function[clj-cbor.tags.numbers/parse-negative-bignum], 2 #function[clj-cbor.tags.numbers/parse-positive-bignum], 35 #function[clj-cbor.tags.text/parse-pattern], 30 #function[clj-cbor.tags.numbers/parse-ratio], 37 #function[clj-cbor.tags.text/parse-uuid], 1004 #function[clj-cbor.tags.time/parse-string-local-date]}, :canonical false, :strict false}}}, :default-serializer :FressianSerializer, :compressor #function[konserve.compressor/null-compressor], :encryptor #function[konserve.encryptor/null-encryptor], :read-handlers #atom[{} 0x1eaa490c], :write-handlers #atom[{} 0x22473c26], :buffer-size 1048576, :locks #atom[{} 0x34f43986], :config {:sync-blob? true, :in-place? false, :lock-blob? true}}
```