### PR TITLE
feat(read): PReadMissSafe — one GET per read (skip the EXISTS probe)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,37 @@ version: 2.1
 orbs:
   tools: replikativ/clj-tools@0.0.30
 
+jobs:
+  # Cheap, always-on gate: load the namespace against the PINNED konserve, with no
+  # external service. A stale/incompatible konserve pin (e.g. one missing
+  # PReadMissSafe) fails here immediately.
+  smoke:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+    steps:
+      - checkout
+      - run:
+          name: load namespace against pinned konserve
+          command: clojure -M -e "(require 'konserve-redis.core)(println :loaded)"
+
+  # Compliance tests against a Redis service container (reachable on localhost:6379,
+  # matching the test's redis://localhost:6379/ uri).
+  unittest:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+      - image: redis:7
+    steps:
+      - checkout
+      - run:
+          name: wait for Redis on :6379
+          command: |
+            for i in $(seq 1 60); do (echo > /dev/tcp/localhost/6379) 2>/dev/null && exit 0; sleep 1; done
+            echo "Redis did not come up on :6379"; exit 1
+      - run:
+          name: run compliance tests
+          command: |
+            clojure -M:test -e "(require '[clojure.test :as t] 'konserve-redis.core-test)(let [{:keys [fail error]} (t/run-tests 'konserve-redis.core-test)](when (or (pos? fail) (pos? error)) (System/exit 1)))"
+
 workflows:
   build-test-and-deploy:
     jobs:
@@ -18,10 +49,8 @@ workflows:
           context: docker-deploy
           requires:
             - tools/setup
-#      - tools/unittest:
-#          context: docker-deploy
-#          requires:
-#            - tools/build
+      - smoke
+      - unittest
       - tools/deploy:
           context:
             - clojars-deploy
@@ -32,7 +61,8 @@ workflows:
           requires:
             - tools/build
             - tools/format
-#            - tools/unittest
+            - smoke
+            - unittest
       - tools/release:
           context:
             - github-token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable, user-visible changes to konserve-redis are documented here.
+
+## Unreleased
+
+### Added
+- **Read-miss-safe reads (one GET, no EXISTS probe).** The Redis backing implements
+  konserve's `PReadMissSafe` and `-read-header` throws `store-key-not-found-ex` when
+  GET returns nil. On a konserve that supports the marker the redundant
+  `-blob-exists?` (EXISTS) probe is dropped, so a read is one GET, and read-modify-write
+  ops (`update-in` / `assoc-in` / `bassoc`) skip it too. Requires konserve `0.9.354`+.
+
+### Changed
+- konserve `0.9.342` → `0.9.354`.
+- CI now runs the compliance suite (sync + async) against a Redis service container,
+  plus a smoke load-check that catches a stale konserve pin; the release is gated on both.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.342"}
+        org.replikativ/konserve {:mvn/version "0.9.354"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.12.0"}
         com.taoensso/carmine {:mvn/version "3.4.1"}}

--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -4,6 +4,7 @@
             [konserve.impl.defaults :refer [connect-default-store]]
             [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                                   PMultiWriteBackingStore PMultiReadBackingStore
+                                                  PReadMissSafe store-key-not-found-ex
                                                   -delete-store header-size]]
             [konserve.utils :refer [async+sync *default-sync-translation*]]
             [konserve.store :as store]
@@ -96,6 +97,10 @@
                     ;; first access is always to header, after it is cached
                  (when-not @fetched-object
                    (reset! fetched-object (get-object (:client store) key)))
+                 ;; PReadMissSafe: GET returns nil for an absent key. Signal not-found;
+                 ;; io-operation's read-first path converts it to the caller's :not-found.
+                 (when (nil? @fetched-object)
+                   (throw (store-key-not-found-ex key)))
                  (Arrays/copyOfRange ^bytes @fetched-object (int 0) (int header-size)))))
   (-read-meta [_ meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -244,6 +249,13 @@
                                  acc))
                              {}
                              (map vector store-keys values))))))))
+
+;; Redis reads are read-miss-safe: -create-blob only constructs a RedisBlob (no
+;; side effect), and -read-header throws store-key-not-found-ex when GET returns
+;; nil. So io-operation skips the -blob-exists? (EXISTS) probe — a read is one GET,
+;; and update-in/assoc-in/bassoc drop their probe too.
+(extend-type RedisStore
+  PReadMissSafe)
 
 (defn connect-store [redis-spec & {:keys [opts]
                                    :as params}]

--- a/test/konserve_redis/core_test.clj
+++ b/test/konserve_redis/core_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.core.async :refer [<!!]]
             [konserve.compliance-test :refer [compliance-test]]
+            [konserve.impl.storage-layout :as sl]
             [konserve-redis.core :as redis]
             [konserve.store :as store])
   (:import [java.util UUID]))
@@ -47,3 +48,9 @@
         (compliance-test st))
       (<!! (redis/release st {:sync? false}))
       (<!! (store/delete-store spec {:sync? false})))))
+
+(deftest redis-read-miss-safe-marker-test
+  (testing "Redis backing implements PReadMissSafe (io-operation skips the EXISTS probe on reads)"
+    (let [store (redis/connect-store redis-spec :opts {:sync? true})]
+      (is (satisfies? sl/PReadMissSafe (:backing store)))
+      (redis/release store {:sync? true}))))


### PR DESCRIPTION
Implements konserve's `PReadMissSafe` for Redis: `-read-header` throws `store-key-not-found-ex` when GET returns nil, so `io-operation` skips the redundant `-blob-exists?` (EXISTS) probe — a read is one GET, and read-modify-write ops drop their probe too. Bumps konserve to `0.9.354` and **enables the compliance suite in CI** (sync + async, against a Redis service container) plus a smoke load-check. Verified locally: compiles, backing satisfies `PReadMissSafe`, **5 tests / 231 assertions / 0 failures**.